### PR TITLE
migrate to decimal package

### DIFF
--- a/lib/src/fixed_decoder.dart
+++ b/lib/src/fixed_decoder.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'scale.dart';
+import 'package:decimal/decimal.dart';
 
 /// Decodes a monetary amount based on a pattern.
 class FixedDecoder {
@@ -22,10 +22,9 @@ class FixedDecoder {
     ArgumentError.checkNotNull(pattern, 'pattern');
   }
 
-  /// Paarses [monetaryValue] and returns
+  /// Parses [monetaryValue] and returns
   /// the value as a BigInt holding the minorUnits
-  BigInt decode(final String monetaryValue) {
-    final negativeOne = BigInt.from(-1);
+  Decimal decode(final String monetaryValue) {
     var majorUnits = BigInt.zero;
     var minorUnits = BigInt.zero;
 
@@ -79,14 +78,9 @@ class FixedDecoder {
       }
     }
 
-    if (isNegative) {
-      majorUnits = majorUnits * negativeOne;
-      minorUnits = minorUnits * negativeOne;
-    }
-
-    final scaleFactor = calcScaleFactor(scale);
-    final value = majorUnits * scaleFactor + minorUnits;
-    return value;
+    final value = Decimal.fromBigInt(majorUnits) +
+        Decimal.fromBigInt(minorUnits) / Decimal.ten.pow(scale);
+    return isNegative ? -value : value;
   }
 
   ///
@@ -248,7 +242,7 @@ class FixedParseException implements Exception {
       required int monetaryIndex,
       required String monetaryValue}) {
     final message = '''
-$monetaryValue contained an unexpected character '${compressedValue[monetaryIndex]}' at pos $monetaryIndex 
+$monetaryValue contained an unexpected character '${compressedValue[monetaryIndex]}' at pos $monetaryIndex
         when a match for pattern character ${compressedPattern[patternIndex]} at pos $patternIndex was expected.''';
     return FixedParseException(message);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,10 +3,11 @@ version: 1.0.0-beta2
 homepage: https://github.com/bsutton/fixed
 description: A starting point for Dart libraries or applications.
 repository: https://github.com/bsutton/fixed
-environment: 
+environment:
   sdk: '>=2.14.4 <3.0.0'
-dependencies: 
+dependencies:
+  decimal: ^1.4.0
   intl: ^0.17.0
-dev_dependencies: 
+dev_dependencies:
   lints: ^1.0.0
   test: ^1.16.0

--- a/test/src/fixed_test.dart
+++ b/test/src/fixed_test.dart
@@ -164,6 +164,15 @@ void main() {
 
     final t3 = Fixed.from(1.01, scale: 2);
     expect(t3.toString(), equals('1.01'));
+
+    final t4 = Fixed.from(-1.01, scale: 0);
+    expect(t4.toString(), equals('-1'));
+
+    final t5 = Fixed.from(-1.01, scale: 1);
+    expect(t5.toString(), equals('-1.0'));
+
+    final t6 = Fixed.from(-1.01, scale: 2);
+    expect(t6.toString(), equals('-1.01'));
   });
 
   test('compare', () {


### PR DESCRIPTION
Following up to https://github.com/noojee/money.dart/issues/54#issuecomment-970085733 here's an attemp to use the decimal package.

(IMHO this package should be merged into money2 directly and remained an implementation detail of money2 inside `src/`)